### PR TITLE
convert the term name to machine readable for file names and class names

### DIFF
--- a/src/Generator.php
+++ b/src/Generator.php
@@ -170,7 +170,10 @@ class Generator
         // Auto construct field name
         $lower = strtolower($this->db_name);
 
-        $this->field_name = "{$lower}__{$this->cv_term}";
+        $term_name_machine = strtolower($this->cv_term);
+        $term_name_machine = str_replace(" ", "_", $term_name_machine);
+
+        $this->field_name = "{$lower}__{$term_name_machine}";
         $this->questions[$this->field_name] = 'field_name';
 
         $files = $this->generate();


### PR DESCRIPTION
This resolves #23 .  What we want to do is *keep the term name as is* so that the cvterm lookup succeeds.  however the file and class names should be converted to lowercase and " " replaced with _